### PR TITLE
Add neutral template color for Watch default activities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.claude/worktrees/
+.DS_Store

--- a/ScoreKeep Watch App/Views/StartView.swift
+++ b/ScoreKeep Watch App/Views/StartView.swift
@@ -20,7 +20,7 @@ struct StartView: View {
     private let indoorVolleyball = ScoreKeepMatchTemplate(
         .volleyball,
         name: "Indoor volleyball",
-        color: .green,
+        color: .neutral,
         environment: .indoor,
         rules: ScoreKeepMatchRules(
             winAt: 3,
@@ -37,7 +37,7 @@ struct StartView: View {
     private let tennis = ScoreKeepMatchTemplate(
         .tennis,
         name: "Tennis",
-        color: .yellow,
+        color: .neutral,
         environment: .outdoor,
         rules: ScoreKeepMatchRules(
             winAt: 1,
@@ -58,7 +58,7 @@ struct StartView: View {
     private let ultimate = ScoreKeepMatchTemplate(
         .ultimate,
         name: "Ultimate frisbee",
-        color: .purple,
+        color: .neutral,
         environment: .outdoor,
         rules: ScoreKeepMatchRules(
             winAt: 1,
@@ -75,7 +75,7 @@ struct StartView: View {
     private let squash = ScoreKeepMatchTemplate(
         .squash,
         name: "Squash",
-        color: .pink,
+        color: .neutral,
         environment: .outdoor,
         rules: ScoreKeepMatchRules(
             winAt: 1,
@@ -92,7 +92,7 @@ struct StartView: View {
     private let pickleball = ScoreKeepMatchTemplate(
         .pickleball,
         name: "Pickleball",
-        color: .green,
+        color: .neutral,
         environment: .outdoor,
         rules: ScoreKeepMatchRules(
             winAt: 1,

--- a/ScoreKeepCore/Sources/ScoreKeepCore/ScoreKeepModels.swift
+++ b/ScoreKeepCore/Sources/ScoreKeepCore/ScoreKeepModels.swift
@@ -812,10 +812,11 @@ public class ScoreKeepWarmup {
 }
 
 public enum ScoreKeepMatchColor: String, Codable {
-    case green, yellow, indigo, purple, teal, blue, orange, pink
+    case neutral, green, yellow, indigo, purple, teal, blue, orange, pink
 
     public var color: Color {
         switch self {
+        case .neutral: return Color.gray
         case .green: return Color.green
         case .yellow: return Color.yellow
         case .indigo: return Color.indigo
@@ -828,7 +829,7 @@ public enum ScoreKeepMatchColor: String, Codable {
     }
 
     public static var allCases: [ScoreKeepMatchColor] {
-        [.green, .yellow, .indigo, .purple, .teal, .blue, .orange, .pink]
+        [.neutral, .green, .yellow, .indigo, .purple, .teal, .blue, .orange, .pink]
     }
 }
 
@@ -838,7 +839,7 @@ public class ScoreKeepMatchTemplate {
 
     public var sport: ScoreKeepSport = ScoreKeepSport.volleyball
     public var name: String = "Volleyball"
-    public var color: ScoreKeepMatchColor = ScoreKeepMatchColor.green
+    public var color: ScoreKeepMatchColor = ScoreKeepMatchColor.neutral
     public var environment: ScoreKeepActivityEnvironment = ScoreKeepActivityEnvironment.indoor
     public var _rules: ScoreKeepMatchRules?
     public var rules: ScoreKeepMatchRules {
@@ -854,7 +855,7 @@ public class ScoreKeepMatchTemplate {
     public init(
         _ sport: ScoreKeepSport,
         name: String,
-        color: ScoreKeepMatchColor = .green,
+        color: ScoreKeepMatchColor = .neutral,
         environment: ScoreKeepActivityEnvironment = .indoor,
         rules: ScoreKeepMatchRules? = nil,
         warmup: ScoreKeepWarmupRule = .open,


### PR DESCRIPTION
## Summary
- Adds a `neutral` case to `ScoreKeepMatchColor` (mapped to `Color.gray`), placed first in `allCases` so it's the lead pick in the color picker.
- Switches the model's stored default and init param default from `.green` to `.neutral`.
- Updates the Watch app's five built-in default templates (volleyball, tennis, ultimate, squash, pickleball) to use `.neutral`, removing per-sport color from the defaults.

## Notes for reviewer
- The iOS app's default templates in `ScoreKeep iOS App/Pages/StartView.swift` still use their old per-sport colors — leaving that for a follow-up unless we want to align them now.
- Existing persisted templates keep whatever color they were saved with; only newly created/default templates pick up `.neutral`.

## Test plan
- [ ] Build and run the Watch app on a fresh simulator (or after uninstalling) and verify the default activities all render in the neutral/gray color.
- [ ] Open the template editor and confirm `.neutral` is the leftmost option in the color picker and selectable.
- [ ] Create a new custom template and confirm it defaults to neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)